### PR TITLE
Add Future City AI-UBI simulation prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,23 @@
 
 Welcome to the Kelvin repository! This is a new project that's ready for development.
 
+## Future Policy Lab
+
+This repository now includes a prototype game called **Future City AI-UBI Simulation** located in `future_city_sim/`. The game combines philosophical simulation, institutional modeling, and system game theory to experiment with AI governance and UBI strategies in a futuristic urban setting.
+
+To play the game:
+
+```bash
+python -m future_city_sim.game
+```
+
 ## Getting Started
 
 ### Prerequisites
 
 - Git installed on your local machine
 - Your favorite code editor
+- Python 3
 
 ### Installation
 

--- a/future_city_sim/README.md
+++ b/future_city_sim/README.md
@@ -1,0 +1,19 @@
+# Future City AI-UBI Simulation
+
+This prototype is an interactive text-based game that explores AI governance, Universal Basic Income (UBI), and societal evolution in a futuristic urban setting. It serves as a "Future Policy Lab" where different policy choices can be tested over a simulated timeline.
+
+## Features
+
+- **Philosophical simulation**: Explore ethical dilemmas around automation and AI.
+- **Institutional modeling**: Experiment with AI governance policies such as high UBI, AI taxation, and technology growth strategies.
+- **System game theory**: See how policy decisions influence population, resources, and happiness over time.
+
+## Running the Game
+
+Ensure you have Python 3 installed. To start the simulation, run:
+
+```bash
+python -m future_city_sim.game
+```
+
+At each simulated year, you will be prompted to choose a policy option. The game will display the resulting changes to population, UBI payments, resources, and overall happiness.

--- a/future_city_sim/game.py
+++ b/future_city_sim/game.py
@@ -1,0 +1,58 @@
+# Future City AI-UBI Simulation Game
+
+from dataclasses import dataclass
+from typing import List, Dict
+
+@dataclass
+class CityState:
+    year: int = 0
+    population: int = 1000
+    ubi: int = 100
+    happiness: float = 0.5
+    resources: float = 1000.0
+    policy: str = "neutral"
+
+class FutureCitySim:
+    def __init__(self, years: int = 10):
+        self.state = CityState()
+        self.years = years
+        self.history: List[CityState] = []
+
+    def apply_policy(self, policy_choice: str):
+        self.state.policy = policy_choice
+        if policy_choice == "high_ubi":
+            self.state.ubi += 50
+            self.state.resources -= 100
+            self.state.happiness += 0.1
+        elif policy_choice == "ai_tax":
+            self.state.resources += 100
+        elif policy_choice == "tech_growth":
+            self.state.resources += 50
+            self.state.happiness += 0.05
+        self.state.happiness = min(max(self.state.happiness, 0), 1)
+
+    def step(self):
+        self.state.year += 1
+        self.state.resources += self.state.population * 0.1
+        self.state.population = int(self.state.population * 1.01)
+        self.history.append(CityState(**vars(self.state)))
+
+    def run(self):
+        print("Welcome to the Future City AI-UBI Simulation!")
+        for _ in range(self.years):
+            print(f"\nYear {self.state.year}")
+            print(f"Population: {self.state.population}")
+            print(f"UBI: {self.state.ubi}")
+            print(f"Resources: {self.state.resources:.2f}")
+            print(f"Happiness: {self.state.happiness:.2f}")
+            choice = input("Choose a policy (high_ubi/ai_tax/tech_growth/none): ")
+            if choice in {"high_ubi", "ai_tax", "tech_growth"}:
+                self.apply_policy(choice)
+            self.step()
+        print("\nSimulation complete. Summary:")
+        for state in self.history:
+            print(state)
+
+if __name__ == "__main__":
+    sim = FutureCitySim()
+    sim.run()


### PR DESCRIPTION
## Summary
- add text-based simulation in `future_city_sim`
- document how to run the game as a Future Policy Lab for AI governance and UBI strategies

## Testing
- `python -m future_city_sim.game`

------
https://chatgpt.com/codex/tasks/task_e_683fa58aeac08326b1f0fc20eae8785d