### PR TITLE
Add Midway simulation prototype modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Welcome to the Kelvin repository! This is a new project that's ready for develop
 
 - Git installed on your local machine
 - Your favorite code editor
+- Python 3.11 or later
 
 ### Installation
 
@@ -16,6 +17,16 @@ Welcome to the Kelvin repository! This is a new project that's ready for develop
 git clone https://github.com/kelvin219/kelvin.git
 cd kelvin
 ```
+
+## Running the Prototype
+
+A small Midway simulation demo is provided. To try it out, simply run:
+
+```bash
+python3 main.py
+```
+
+You should see the rhythm chain stages printed along with decision window feedback.
 
 ## Contributing
 

--- a/main.py
+++ b/main.py
@@ -1,0 +1,31 @@
+from midway_sim.fleet_cycle import FleetCycle
+from midway_sim.info_fuzz import InfoFuzz
+from midway_sim.time_cone import TimeCone
+from midway_sim.disturbance import Disturbance
+from midway_sim.ai_judgment import AIJudgment
+
+
+def main() -> None:
+    cycle = FleetCycle()
+    fuzz = InfoFuzz()
+    cone = TimeCone(duration=10, window=(2, 4))
+    weather = Disturbance("weather", delay=1)
+    ai = AIJudgment()
+    targets = ["CV-1", "BB-2", "DD-3"]
+
+    while not cone.completed():
+        cone.tick()
+        stage = cycle.current_stage
+        message = f"Stage: {stage}, time={cone.time}"
+
+        if cone.within_window() and stage == "attack":
+            target = ai.choose_attack_target(targets)
+            message += f" -> attacking {target}"
+            message = weather.apply(message)
+
+        print(fuzz.apply_fuzz(message))
+        cycle.advance()
+
+
+if __name__ == "__main__":
+    main()

--- a/midway_sim/__init__.py
+++ b/midway_sim/__init__.py
@@ -1,0 +1,1 @@
+"Midway simulator game modules"

--- a/midway_sim/ai_judgment.py
+++ b/midway_sim/ai_judgment.py
@@ -1,0 +1,11 @@
+import random
+
+
+class AIJudgment:
+    """Very simple decision making for attack targets."""
+
+    def choose_attack_target(self, targets: list[str]) -> str | None:
+        if not targets:
+            return None
+        # Imperfect choice: pick randomly instead of smartest option
+        return random.choice(targets)

--- a/midway_sim/disturbance.py
+++ b/midway_sim/disturbance.py
@@ -1,0 +1,10 @@
+class Disturbance:
+    """Represent an asynchronous factor that slows operations."""
+
+    def __init__(self, name: str, delay: int = 1):
+        self.name = name
+        self.delay = delay
+
+    def apply(self, stage: str) -> str:
+        """Return a message describing the disturbance impact."""
+        return f"{stage} delayed by {self.name} (+{self.delay}t)"

--- a/midway_sim/fleet_cycle.py
+++ b/midway_sim/fleet_cycle.py
@@ -1,0 +1,22 @@
+class FleetCycle:
+    """Simple cycle for carrier aircraft operations."""
+
+    stages = [
+        "takeoff",
+        "load",
+        "attack",
+        "return",
+        "recovery",
+    ]
+
+    def __init__(self):
+        self.index = 0
+
+    @property
+    def current_stage(self) -> str:
+        return self.stages[self.index]
+
+    def advance(self) -> str:
+        """Move to the next stage and return its name."""
+        self.index = (self.index + 1) % len(self.stages)
+        return self.current_stage

--- a/midway_sim/info_fuzz.py
+++ b/midway_sim/info_fuzz.py
@@ -1,0 +1,14 @@
+import random
+
+
+class InfoFuzz:
+    """Apply a simple fog-of-war to messages."""
+
+    def __init__(self, delay_chance: float = 0.2):
+        self.delay_chance = delay_chance
+
+    def apply_fuzz(self, info: str) -> str:
+        """Return possibly delayed/altered information."""
+        if random.random() < self.delay_chance:
+            return f"{info} (delayed)"
+        return info

--- a/midway_sim/time_cone.py
+++ b/midway_sim/time_cone.py
@@ -1,0 +1,17 @@
+class TimeCone:
+    """Model a simple decision window against actual time."""
+
+    def __init__(self, duration: int, window: tuple[int, int]):
+        self.time = 0
+        self.duration = duration
+        self.window = window
+
+    def tick(self, amount: int = 1) -> None:
+        self.time += amount
+
+    def within_window(self) -> bool:
+        start, end = self.window
+        return start <= self.time <= end
+
+    def completed(self) -> bool:
+        return self.time >= self.duration


### PR DESCRIPTION
## Summary
- add basic game modules under `midway_sim/`
- create a small interactive demo in `main.py`
- document how to run the prototype

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687b8654f9b88326835de41274d4e697