### PR TITLE
feat: scaffold Next.js demo pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+out
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,30 +1,17 @@
-# Kelvin
+# Kelvin App
 
-Welcome to the Kelvin repository! This is a new project that's ready for development.
+This repository contains a minimal Next.js project scaffolded without installing dependencies.
 
-## Getting Started
+## Scripts
 
-### Prerequisites
+- `npm run dev` – start development server
+- `npm run build` – build the application
+- `npm start` – run the built app
 
-- Git installed on your local machine
-- Your favorite code editor
+## Pages
 
-### Installation
+- `/` – Home with link to demos
+- `/demos` – List of demos linking to individual demo pages
+- `/demos/[id]` – Displays selected demo id
 
-1. Clone the repository:
-```bash
-git clone https://github.com/kelvin219/kelvin.git
-cd kelvin
-```
-
-## Contributing
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/AmazingFeature`)
-3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
-4. Push to the branch (`git push origin feature/AmazingFeature`)
-5. Open a Pull Request
-
-## License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+Dependencies are not installed by default. Run `npm install` to install required packages.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "kelvin-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "next": "14.0.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/pages/demos/[id].jsx
+++ b/pages/demos/[id].jsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+export default function DemoDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+
+  return (
+    <main>
+      <h1>Demo Detail</h1>
+      <p>Currently viewing demo: {id}</p>
+      <nav>
+        <Link href="/demos">Back to Demos</Link>
+      </nav>
+    </main>
+  );
+}

--- a/pages/demos/index.jsx
+++ b/pages/demos/index.jsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+
+const demos = ['demo1', 'demo2'];
+
+export default function DemoList() {
+  return (
+    <main>
+      <h1>Demos</h1>
+      <nav>
+        <Link href="/">Home</Link>
+      </nav>
+      <ul>
+        {demos.map((id) => (
+          <li key={id}>
+            <Link href={`/demos/${id}`}>{id}</Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,0 +1,12 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Welcome to Kelvin App</h1>
+      <nav>
+        <Link href="/demos">View Demos</Link>
+      </nav>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold minimal Next.js project structure
- add home page linking to demos
- add demos listing and dynamic demo detail page with navigation

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/next)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894e9baff3c8326af00b70c5428f506