### PR TITLE
Remove unused Dict import from game module

### DIFF
--- a/future_city_sim/game.py
+++ b/future_city_sim/game.py
@@ -1,7 +1,7 @@
 # Future City AI-UBI Simulation Game
 
 from dataclasses import dataclass
-from typing import List, Dict
+from typing import List
 
 @dataclass
 class CityState:


### PR DESCRIPTION
## Summary
- remove the unused Dict import from future_city_sim/game.py to satisfy lint checks

## Testing
- ruff check

------
https://chatgpt.com/codex/tasks/task_e_68e1499f2b0483268eef1ae22d4aef68